### PR TITLE
[FIX] Retirado uso do PEP 494 (só disponível em python 3.6)

### DIFF
--- a/pybrasil/febraban/processador_boleto.py
+++ b/pybrasil/febraban/processador_boleto.py
@@ -91,8 +91,8 @@ class ProcessadorBoleto(object):
             return xml
 
         for namespace, url in self.configuracao[operacao].assinatura.namespaces.items():
-            xml = xml.replace(f'xmlns:{namespace}="{url}"', '')
-            xml = xml.replace(f'xmlns="{url}"', '')
+            xml = xml.replace('xmlns:{namespace}="{url}"'.format(namespace=namespace, url=url), '')
+            xml = xml.replace('xmlns="{url}"'.format(url=url), '')
 
         return xml
 
@@ -179,11 +179,11 @@ class ProcessadorBoleto(object):
                 if not deu_certo:
                     if configuracao.tag_erro_codigo:
                         texto_erro = getattr(conexao.retorno, configuracao.tag_erro_codigo, '')
-                        mensagem_erro += f'Código de retorno: {texto_erro}\n'
+                        mensagem_erro += 'Código de retorno: {texto_erro}\n'.format(texto_erro=texto_erro)
 
                     if configuracao.tag_erro_descricao:
                         texto_erro = getattr(conexao.retorno, configuracao.tag_erro_descricao, '')
-                        mensagem_erro += f'Mensagem: {texto_erro}\n'
+                        mensagem_erro += 'Mensagem: {texto_erro}\n'.format(texto_erro=texto_erro)
 
                 conexao.mensagem_erro = mensagem_erro
 
@@ -195,11 +195,11 @@ class ProcessadorBoleto(object):
 
                     if configuracao.tag_erro_codigo:
                         texto_erro = getattr(erro, configuracao.tag_erro_codigo, '')
-                        mensagem_erro += f'Código de retorno: {texto_erro}\n'
+                        mensagem_erro += 'Código de retorno: {texto_erro}\n'.format(texto_erro=texto_erro)
 
                     if configuracao.tag_erro_descricao:
                         texto_erro = getattr(erro, configuracao.tag_erro_descricao, '')
-                        mensagem_erro += f'Mensagem: {texto_erro}\n'
+                        mensagem_erro += 'Mensagem: {texto_erro}\n'.format(texto_erro=texto_erro)
 
                 conexao.mensagem_erro = mensagem_erro
 


### PR DESCRIPTION
Retira o uso do PEP 494 para permitir a pybrasil ser usada em python 2.7 junto com python3.x